### PR TITLE
fix: height should be the second parameter returned from onContentSizeChange

### DIFF
--- a/custom-scroll-indicator/App.js
+++ b/custom-scroll-indicator/App.js
@@ -47,7 +47,7 @@ export default function App() {
               contentContainerStyle={{ paddingRight: 14 }}
               showsVerticalScrollIndicator={false}
               scrollEventThrottle={16}
-              onContentSizeChange={height => {
+              onContentSizeChange={(width, height) => {
                 setCompleteScrollBarHeight(height);
               }}
               onLayout={({


### PR DESCRIPTION
The `onContentSizeChange` prop of the Scrollview returns the `height` as the second parameter so the Custom Scrollbar example is using the wrong dimension. It does however happen to work because of the empty View at the bottom which has `flex: 4` making the ScrollView small enough for the wrong dimensions to work.

Using the actual `height` does however fix this and allows a full length Scrollbar to work great!

P.S. This is the best custom scrollbar implementation I've seen for RN, thank you! 👍 